### PR TITLE
supporting new interface and handling peer add notification

### DIFF
--- a/client_cpp/lib/mediasoup_conference/conference_handler.cpp
+++ b/client_cpp/lib/mediasoup_conference/conference_handler.cpp
@@ -114,9 +114,15 @@ namespace grt {
 
 			consumer_transport_.reset(transport);
 
+			const auto m = make_participant_info_req();
+			signaller_->send(m);
+
 		}
 		else if (grt::message_type::peer_add == type) {
 			const auto peer_id = absl::any_cast<std::string>(msg);
+			if (consumer_transport_.get() == nullptr || consumers_.find(peer_id) != consumers_.end())
+				return;//ignore this.
+			
 			assert(consumers_.find(peer_id) == consumers_.end());
 
 			//todo: check if consumer is already created for this peer id.


### PR DESCRIPTION
1. support of sending participant request.
2. checking for peer-add notification if consumer transport is created or duplication request handling.